### PR TITLE
sticky keys edit. windows/chrome voice fix.

### DIFF
--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -199,7 +199,7 @@ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
         },
         model: {
             // offerAssistance: boolean
-            tryAccommodation: false,
+            tryAccommodation: true,
             userInput: ""
         },
         components: {

--- a/src/lib/infusion/infusion-custom.js
+++ b/src/lib/infusion/infusion-custom.js
@@ -31830,6 +31830,13 @@ var fluid_2_0 = fluid_2_0 || {};
         };
         $.extend(toSpeak, that.model.utteranceOpts, options, eventBinding);
 
+		toSpeak.voice = speechSynthesis.getVoices().filter(function(voice){return voice.lang == toSpeak.lang;})[0];
+		// Search by language regardless of dialect when a voice couldn't be found
+		if (toSpeak.voice == null) {
+			toSpeak.voice = speechSynthesis.getVoices().filter(function (voice) {
+				return voice.lang.substring(0, 2) == toSpeak.lang.substring(0, 2);
+			})[0];
+		}
         that.queue.push(text);
         that.events.onSpeechQueued.fire(text);
         speechSynthesis.speak(toSpeak);


### PR DESCRIPTION
sticky keys edit - Remove the middle "Try it" step. When a user fails to enter a % character they will go directly to the sticky keys demo panel

windows/chrome voice error fix - bypass native and use chrome voice options
