### PR TITLE
Enabled keydown handler on iFrame preview

### DIFF
--- a/src/js/keyboardShortcut.js
+++ b/src/js/keyboardShortcut.js
@@ -1,12 +1,12 @@
 /*
-Copyright 2015 OCAD University
+ Copyright 2015 OCAD University
 
-Licensed under the New BSD license. You may not use this file except in
-compliance with this License.
+ Licensed under the New BSD license. You may not use this file except in
+ compliance with this License.
 
-You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
-*/
+ You may obtain a copy of the License at
+ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
+ */
 
 (function ($, fluid) {
 
@@ -52,19 +52,49 @@ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
      * func {Object} - the function to call when the shortcut is triggered.
      */
     gpii.firstDiscovery.keyboardShortcut.bindShortcut = function (elm, key, modifiers, func) {
+        var jQueryElement = $(elm);
+        gpii.firstDiscovery.keyboardShortcut.bindShortcutToElement(jQueryElement, key, modifiers, func);
+    };
+
+
+    /**
+     * elm {Object} - any jQueryable selector referring to the element to bind a keypress to
+     * key {Int} - An integer representation of the key to bind as a shortcut (see: gpii.firstDiscovery.keyboardShortcut.key)
+     * modifiers {Array} - an array of modifiers required ("altKey", "ctrlKey", "metaKey", "shiftKey")
+     * func {Object} - the function to call when the shortcut is triggered.
+     * previewIframeSelector - any jQueryable selector referring to the iframe element holding the preview to serve as context for the search in for elm
+     */
+    gpii.firstDiscovery.keyboardShortcut.bindShortcutInPreviewIFrame = function (elm, key, modifiers, func, previewIframeSelector) {
+        // Wait for the preview to load then bind the keyboard shortcut
+        $(previewIframeSelector).load(function () {
+            var jQueryElement = $(previewIframeSelector).contents().find(elm);
+            gpii.firstDiscovery.keyboardShortcut.bindShortcutToElement(jQueryElement, key, modifiers, func);
+        });
+    };
+
+
+    /**
+     * jQueryElement {Object} - any jQueryable element referring to the element to bind a keypress to
+     * key {Int} - An integer representation of the key to bind as a shortcut (see: gpii.firstDiscovery.keyboardShortcut.key)
+     * modifiers {Array} - an array of modifiers required ("altKey", "ctrlKey", "metaKey", "shiftKey")
+     * func {Object} - the function to call when the shortcut is triggered.
+     */
+    gpii.firstDiscovery.keyboardShortcut.bindShortcutToElement = function (jQueryElement, key, modifiers, func) {
         modifiers = fluid.arrayToHash(modifiers || []);
 
-        $(elm).keydown(function (e) {
+        jQueryElement.keydown(function (e) {
             var checkModifier = function (modKey, current) {
-                return current && !!e[modKey] === !!modifiers[modKey]; /* convert to boolean */ /* jshint ignore:line */
+                return current && !!e[modKey] === !!modifiers[modKey];
+                /* convert to boolean */
+                /* jshint ignore:line */
             };
 
             var isCorrectlyModified = fluid.accumulate(gpii.firstDiscovery.keyboardShortcut.modfiers, checkModifier, true);
 
             if (e.which === key && isCorrectlyModified) {
-                func();
+                    func();
             }
         });
-    };
+    }
 
 })(jQuery, fluid);

--- a/src/js/ttsHookup.js
+++ b/src/js/ttsHookup.js
@@ -58,6 +58,10 @@ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
                 listener: "gpii.firstDiscovery.keyboardShortcut.bindShortcut",
                 args: ["body", gpii.firstDiscovery.keyboardShortcut.key.h, [], "{that}.speakPanelInstructions"]
             },
+            "onCreate.bindKeyPressPreview": {
+                listener: "gpii.firstDiscovery.keyboardShortcut.bindShortcutInPreviewIFrame",
+                args: ["body", gpii.firstDiscovery.keyboardShortcut.key.h, [], "{that}.speakPanelInstructions", "#thePreview"]
+            },
             "onReady.speakPanelMessage": {
                 listener: "{that}.speakPanelMessage",
                 priority: "last"

--- a/tests/html/keyboardShortcut-Tests.html
+++ b/tests/html/keyboardShortcut-Tests.html
@@ -26,5 +26,7 @@
 
         <span class="keyboardShortcut-test"></span>
 
+        <iframe id="thePreview" src="keyboardShortcut-iFrame-Tests.html"></iframe>
+
     </body>
 </html>

--- a/tests/html/keyboardShortcut-iFrame-Tests.html
+++ b/tests/html/keyboardShortcut-iFrame-Tests.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Keyboard Shorcut Tests IFrame</title>
+
+        <link rel="stylesheet" media="screen" href="../lib/infusion/lib/qunit/css/qunit.css" />
+        <link rel="stylesheet" media="screen" href="../../src/css/style.css" />
+
+
+    </head>
+
+    <body id="body">
+
+
+    </body>
+</html>

--- a/tests/js/keyboardShortcutTests.js
+++ b/tests/js/keyboardShortcutTests.js
@@ -1,12 +1,12 @@
 /*!
-Copyright 2015 OCAD University
+ Copyright 2015 OCAD University
 
-Licensed under the New BSD license. You may not use this file except in
-compliance with this License.
+ Licensed under the New BSD license. You may not use this file except in
+ compliance with this License.
 
-You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
-*/
+ You may obtain a copy of the License at
+ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
+ */
 
 (function ($, fluid) {
     "use strict";
@@ -114,6 +114,7 @@ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
         };
     };
 
+
     jqUnit.test("gpii.firstDiscovery.keyboardShortcut.bindShortcut", function () {
         var elm = $(".keyboardShortcut-test");
         var fireRecord = {};
@@ -151,4 +152,86 @@ https://raw.githubusercontent.com/GPII/first-discovery/master/LICENSE.txt
         jqUnit.assertDeepEq("The shortcuts should have been triggered the correct number of times", expectedRecord, fireRecord);
     });
 
-})(jQuery, fluid);
+    jqUnit.test("gpii.firstDiscovery.keyboardShortcut.bindShortcutToElement", function () {
+        var elm = $(".keyboardShortcut-test");
+        var fireRecord = {};
+        var expectedRecord = {
+            "a": 1,
+            "alt-a": 1,
+            "ctrl-a": 1,
+            "meta-a": 1,
+            "shift-a": 1,
+            "alt-ctrl-a": 1,
+            "alt-meta-a": 1,
+            "alt-shift-a": 1,
+            "ctrl-meta-a": 1,
+            "ctrl-shift-a": 1,
+            "meta-shift-a": 1,
+            "alt-ctrl-meta-a": 1,
+            "alt-ctrl-shift-a": 1,
+            "alt-meta-shift-a": 1,
+            "ctrl-meta-shift-a": 1,
+            "alt-ctrl-meta-shift-a": 1
+        };
+
+        // bind shortcuts
+        fluid.each(gpii.tests.keyboardShortcut.shortcuts, function (shortcuts, shortcutName) {
+            gpii.firstDiscovery.keyboardShortcut.bindShortcutToElement(elm, shortcuts.key, shortcuts.modifiers, gpii.tests.keyboardShortcut.handlerFnCreator(fireRecord, shortcutName));
+        });
+
+        // run through key strokes
+        fluid.each(gpii.firstDiscovery.keyboardShortcut.key, function (keyCode) {
+            fluid.each(gpii.tests.keyboardShortcut.modifiersTestCases, function (modifiers) {
+                gpii.tests.utils.simulateKeyEvent(elm, "keydown", keyCode, modifiers);
+            });
+        });
+
+        jqUnit.assertDeepEq("The shortcuts should have been triggered the correct number of times", expectedRecord, fireRecord);
+    });
+
+
+    // TODO: These tests are broken. The event handlers are wired up on the iFrame but they do not seem to ever
+    // call the callback, thus fireRecord is an empty {}. As of 24-FEB-2016, the tests are failing but manual
+    // tests show the bindShortcutInPreviewIFrame function is working.
+    jqUnit.test("gpii.firstDiscovery.keyboardShortcut.bindShortcutInPreviewIFrame", function () {
+
+        console.log("running bindShortcutInPreviewIframe tests");
+        var elm = "body";
+        var previewIframeSelector = "#thePreview";
+        var simulateElement = $(previewIframeSelector).contents().find(elm);
+        var fireRecord = {};
+        var expectedRecord = {
+            "a": 1,
+            "alt-a": 1,
+            "ctrl-a": 1,
+            "meta-a": 1,
+            "shift-a": 1,
+            "alt-ctrl-a": 1,
+            "alt-meta-a": 1,
+            "alt-shift-a": 1,
+            "ctrl-meta-a": 1,
+            "ctrl-shift-a": 1,
+            "meta-shift-a": 1,
+            "alt-ctrl-meta-a": 1,
+            "alt-ctrl-shift-a": 1,
+            "alt-meta-shift-a": 1,
+            "ctrl-meta-shift-a": 1,
+            "alt-ctrl-meta-shift-a": 1
+        };
+
+        // bind shortcuts
+        fluid.each(gpii.tests.keyboardShortcut.shortcuts, function (shortcuts, shortcutName) {
+            gpii.firstDiscovery.keyboardShortcut.bindShortcutInPreviewIFrame(elm, shortcuts.key, shortcuts.modifiers, gpii.tests.keyboardShortcut.handlerFnCreator(fireRecord, shortcutName), previewIframeSelector);
+        });
+
+        // run through key strokes
+        fluid.each(gpii.firstDiscovery.keyboardShortcut.key, function (keyCode) {
+            fluid.each(gpii.tests.keyboardShortcut.modifiersTestCases, function (modifiers) {
+                gpii.tests.utils.simulateKeyEvent(elm, "keydown", keyCode, modifiers);
+            });
+        });
+
+        jqUnit.assertDeepEq("The shortcuts should have been triggered the correct number of times", expectedRecord, fireRecord);
+    });
+})
+(jQuery, fluid);


### PR DESCRIPTION
Extracted keydown event binding to a separate function that now
expects a jQuery element. Pointed existing keydown calls at this
new function to preserve the method signature of existing callers.
Added new function that handles registering keydown event handlers
on the iFrame preview. This also points to the common function to
actually register the event handler.
